### PR TITLE
Updated ownership settings in uptimerc

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -1,18 +1,18 @@
-owner: brittonhayes # GitHub username
+owner: 5e-bits # GitHub username
 repo: dnd-uptime # GitHub repository name
 status-website:
   name: D&D API Status
   logoUrl: https://www.dnd5eapi.co/public/favicon.ico
   baseUrl: /dnd-uptime
   introTitle: "**Status** tracks the uptime of the D&D REST API"
-  introMessage: This status page uses **real-time** data from our [Github repository](https://github.com/brittonhayes/dnd-uptime). No server required — just GitHub Actions, Issues, and Pages.
+  introMessage: This status page uses **real-time** data from our [Github repository](https://github.com/5e-bits/dnd-uptime). No server required — just GitHub Actions, Issues, and Pages.
   navbar:
     - title: Status
       href: /dnd-uptime
     - title: API
-      href: https://github.com/bagelbits/5e-srd-api
+      href: https://github.com/5e-bits/5e-srd-api
     - title: Database
-      href: https://github.com/bagelbits/5e-database
+      href: https://github.com/5e-bits/5e-database
 
 sites: # List of endpoints to track
   - name: DnD 5e API


### PR DESCRIPTION
This pull request transfers the Github pages site to the 5e-bits organization by updating the `yml` config.